### PR TITLE
update for babel6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,9 +7,7 @@ module.exports = function (grunt) {
         babel: {
             options: {
                 sourceMaps: 'inline',
-                nonStandard: false,
-                optional: [ 'strict' ],
-                stage: 0,
+                presets: ['babel-preset-es2015']
             },
             src: {
                 expand: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-source-map-support",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Babel plugin which automatically makes stack traces source-map aware",
   "repository": "chocolateboy/babel-plugin-source-map-support",
   "license": "Artistic-2.0",
@@ -12,21 +12,22 @@
     "target/src/plugin.js"
   ],
   "dependencies": {
-    "babel-runtime": "^5.8.34",
-    "babel-core": "^5.8.34"
+    "babel-core": "^6.4.5",
+    "babel-runtime": "^6.3.19"
   },
   "devDependencies": {
-    "babel-plugin-espower": "^1.1.0",
+    "babel-plugin-espower": "~2.1.0",
+    "babel-preset-es2015": "~6.3.13",
     "espurify": "^1.3.0",
     "grunt": "^0.4.5",
-    "grunt-babel": "^5.0.3",
+    "grunt-babel": "^6.0.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-mocha-test": "^0.12.7",
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^2.3.4",
     "power-assert": "^1.2.0",
-    "source-map-support": "^0.3.3"
+    "source-map-support": "~0.4.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/test/fixtures/expected.json
+++ b/test/fixtures/expected.json
@@ -1,49 +1,112 @@
 {
+    "type": "Program",
     "body": [
         {
-            "source": {
-                "type": "Literal",
-                "value": "foo"
-            },
+            "type": "ImportDeclaration",
             "specifiers": [
                 {
-                    "local": {
-                        "name": "foo",
-                        "type": "Identifier"
+                    "type": "ImportSpecifier",
+                    "imported": {
+                        "type": "Identifier",
+                        "name": "install"
                     },
-                    "type": "ImportDefaultSpecifier"
+                    "local": {
+                        "type": "Identifier",
+                        "name": "_sourceMapSupport"
+                    }
                 }
             ],
-            "type": "ImportDeclaration"
-        },
-        {
             "source": {
-                "type": "Literal",
-                "value": "bar"
-            },
-            "specifiers": [
-                {
-                    "local": {
-                        "name": "bar",
-                        "type": "Identifier"
-                    },
-                    "type": "ImportDefaultSpecifier"
-                }
-            ],
-            "type": "ImportDeclaration"
+                "type": "StringLiteral",
+                "value": "source-map-support"
+            }
         },
         {
+            "type": "ExpressionStatement",
             "expression": {
-                "arguments": [],
+                "type": "CallExpression",
                 "callee": {
-                    "name": "test",
-                    "type": "Identifier"
+                    "type": "Identifier",
+                    "name": "_sourceMapSupport"
                 },
-                "type": "CallExpression"
-            },
-            "type": "ExpressionStatement"
+                "arguments": [ ]
+            }
+        },
+        {
+            "type": "ImportDeclaration",
+            "specifiers": [
+                {
+                    "type": "ImportDefaultSpecifier",
+                    "local": {
+                        "type": "Identifier",
+                        "name": "foo"
+                    }
+                }
+            ],
+            "source": {
+                "type": "StringLiteral",
+                "start": 16,
+                "end": 21,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 21
+                    }
+                },
+                "extra": {
+                    "rawValue": "foo",
+                    "raw": "'foo'"
+                },
+                "value": "foo"
+            }
+        },
+        {
+            "type": "ImportDeclaration",
+            "specifiers": [
+                {
+                    "type": "ImportDefaultSpecifier",
+                    "local": {
+                        "type": "Identifier",
+                        "name": "bar"
+                    }
+                }
+            ],
+            "source": {
+                "type": "StringLiteral",
+                "start": 39,
+                "end": 44,
+                "loc": {
+                    "start": {
+                        "line": 2,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 21
+                    }
+                },
+                "extra": {
+                    "rawValue": "bar",
+                    "raw": "'bar'"
+                },
+                "value": "bar"
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "CallExpression",
+                "callee": {
+                    "type": "Identifier",
+                    "name": "test"
+                },
+                "arguments": [ ]
+            }
         }
     ],
-    "sourceType": "module",
-    "type": "Program"
+    "sourceType": "module"
 }

--- a/test/src/test.js
+++ b/test/src/test.js
@@ -5,29 +5,28 @@ import Path                  from 'path'
 import { transformFileSync } from 'babel-core'
 
 // XXX rootrequire (amongst others) doesn't work with nom
-const root = Path.resolve(__dirname, '../../..')
+const root = Path.resolve(__dirname, '../../..');
 
 function dump ({ code, ast }) {
-    console.log(code)
-    console.log(JSON.stringify(espurify(ast.program), null, 4))
+    console.log(code);
+    console.log(JSON.stringify(espurify(ast.program), null, 4));
 }
 
-let pluginPath = `${root}/target/src/plugin.js`
+let pluginPath = `${root}/target/src/plugin.js`;
 
 describe('plugin', () => {
     it('prepends a require', () => {
-        let fixture = `${root}/test/fixtures/actual.js`
+        let fixture = `${root}/test/fixtures/actual.js`;
 
         let output = transformFileSync(fixture, {
-            blacklist: [ 'es6.modules', 'strict' ],
             plugins: [ pluginPath ]
-        })
+        });
 
         // dump(output)
 
-        let got = espurify(output.ast.program)
-        let want = require(`${root}/test/fixtures/expected.json`)
+        let got = espurify(output.ast.program);
+        let want = require(`${root}/test/fixtures/expected.json`);
 
         assert.deepEqual(got, want)
     })
-})
+});


### PR DESCRIPTION
I don't known babel very well. But I really need to use this plugin in babel6, so I made some improvements.

+ version in package.json 
+ dependencies in package.json
+ Gruntfile compile cmd
+ src/plugin.js for babel 6
+ test file

In addition:
I don't find good method to add import like what `require('source-map-support/register')` does. So I use method below:

    add `import { install as _sourceMapSupport } from 'source-map-support';`
    then call `_sourceMapSupport();`

It seems that babel6 doesn't support import third party module without export.
You can see [babel issue about it](https://phabricator.babeljs.io/T1436)